### PR TITLE
#2 again: Cannot read property of _value of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,12 @@ module.exports = class EmitAllPlugin {
                     if (this.ignoreExternals && mod.external) return;
                     if (this.shouldIgnore(absolutePath)) return;
 
-                    // Used for vendor chunk
-                    if (mod.constructor.name === 'MultiModule') return;
+                    // Used for vendor chunks like:
+                    // MultiModule
+                    // ConcatenatedModule
+                    // ExternalModule
+                    // ContextModule
+                    if (mod._source === null) return;
 
                     const source = mod._source._value;
                     const projectRoot = compiler.context;


### PR DESCRIPTION
Hi all,

I'm compiling a TypeScript library to be used on Node Applications (Lambdas). I tried using this plugin but couldn't get past the `cannot read property of _value of undefined` problem.

Turns out `_source` comes null for more than `MultiModule`. The first one I found was `ConcatenatedModule`. 

![index_js_ _horseshoe](https://user-images.githubusercontent.com/779325/42137189-0de0e9b2-7d36-11e8-9e93-a83bd5e41c9d.png)

I kept digging and found that `_source` also comes null for everyone on this list (but not limited to tho):

  - MultiModule
  - ConcatenatedModule
  - ExternalModule
  - ContextModule

I tried just doing `if (mod._source === null) return;` with great success, all my TS code appeared in a single folder as javascript, but with the `.ts` file extension.

So I added the following to handle this:

```js
const path = require('path');
const EmitAllPlugin = require('webpack-emit-all-plugin');
{
    plugins: [
        new EmitAllPlugin({
            ignorePattern: /node_modules/ // default,
            path: path.join(__dirname, 'unbundled-out') // defaults to `output.path`
            fileExtension: 'js', // replaces any .ext with this one
            replacePath: { 
                path: 'src',  // if the output file has /src/ on it 
                replacement: '' // replace it with this
            }
        })
    ]
}
```

This might not be desired/wanted I just did it because it was pretty simple, so no hard feelings if it's a non-issue and you close it.