### PR TITLE
Fix 'Cannot read property '_value' of null' error for ContextModules

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = class EmitAllPlugin {
                     if (this.shouldIgnore(absolutePath)) return;
 
                     // Used for vendor chunk
-                    if (mod.constructor.name === 'MultiModule') return;
+                    // Excludes MultiModules as well as ContextModules
+                    if (!mod._source) return;
 
                     const source = mod._source._value;
                     const projectRoot = compiler.context;


### PR DESCRIPTION
This fixes the `Cannot read property '_value' of null` error discussed in #2 and #6 for ContextModules in addition to MultiModules. Since we only want to emit modules with `_source` values, this seems like a relatively safe fix.